### PR TITLE
Babel

### DIFF
--- a/agents/motd.js
+++ b/agents/motd.js
@@ -1,28 +1,27 @@
 'use strict';
 
-var Bluebird = require('bluebird');
-var spreadsheet = require('../spreadsheet.js');
-var interval = require('../interval.js');
-var getRows = Bluebird.promisify(spreadsheet.api.getRows, spreadsheet.api);
-var MAIN_CHANNEL_ID = '108312291618885632'; // #members-chat
-var ONE_HOUR = 60 * 60 * 1000;
-var _intervalToken;
+import Bluebird from 'bluebird';
+import * as spreadsheet from '../spreadsheet.js';
+import * as interval from '../interval.js';
 
-module.exports.start = function (bot) {
-	_intervalToken = interval.set(function () {
+const getRows = Bluebird.promisify(spreadsheet.api.getRows, spreadsheet.api);
+const MAIN_CHANNEL_ID = '108312291618885632'; // #members-chat
+const ONE_HOUR = 60 * 60 * 1000;
+let _intervalToken;
+
+export function start (bot) {
+	_intervalToken = interval.set(() => {
 		return getRows(spreadsheet.sheets.info) // return the promise for unit tests
-			.then(function (data) {
-				data.forEach(function (row) {
+			.then((data) => {
+				data.forEach((row) => {
 					if (row.name === 'MOTD') bot.sendMessage(MAIN_CHANNEL_ID, row.message);
 				});
 			})
-			.catch(function (err) {
-				console.error(err);
-			});
+			.catch((err) => console.error(err));
 	}, 3 * ONE_HOUR);
 	return _intervalToken; // return for the unit test to use
 };
 
-module.exports.stop = function () {
+export function stop () {
 	interval.clear(_intervalToken);
 };

--- a/agents/motd.js
+++ b/agents/motd.js
@@ -1,10 +1,9 @@
 'use strict';
 
 import Bluebird from 'bluebird';
-import * as spreadsheet from '../spreadsheet.js';
+import {getRows, sheets} from '../spreadsheet.js';
 import * as interval from '../interval.js';
 
-const getRows = Bluebird.promisify(spreadsheet.api.getRows, {context: spreadsheet.api});
 const MAIN_CHANNEL_ID = '108312291618885632'; // #members-chat
 const ONE_HOUR = 60 * 60 * 1000;
 let _intervalToken;
@@ -13,7 +12,7 @@ export function start (bot) {
 	const sendMessage = Bluebird.promisify(bot.sendMessage, {context: bot});
 	_intervalToken = interval.set(async () => {
 		try {
-			const data = await getRows(spreadsheet.sheets.info) // return the promise for unit tests
+			const data = await getRows(sheets.info) // return the promise for unit tests
 			for (let row of data) {
 				if (row.name === 'MOTD') await sendMessage(MAIN_CHANNEL_ID, row.message);
 			};

--- a/bot.js
+++ b/bot.js
@@ -22,7 +22,8 @@ export default (bot) => {
 	bot.on('message', async (message) => {
 		if (message.content.substr(0, 1) !== '!') return;
 
-		const reply = Bluebird.promisify(message.reply, {context: message});
+		message.replyp = Bluebird.promisify(message.reply, {context: message});
+
 		const structure = message.content.split(' ');
 		const command = structure[0];
 		const theRest = structure.slice(1, structure.length);
@@ -33,7 +34,7 @@ export default (bot) => {
 				const item = commands[key].help;
 				return `\n!${key}${item.context ? ' ' + item.context : ''} :: ${item.info}`;
 			});
-			await reply(help.join(''));
+			await message.replyp(help.join(''));
 		} else {
 			const commandFn = commands[command.substring(1)];
 			if (commandFn) {

--- a/bot.js
+++ b/bot.js
@@ -1,10 +1,11 @@
 'use strict';
 
-var Bluebird = require('bluebird');
-var agents = [
+import Bluebird from 'bluebird';
+
+const agents = [
 	require('./agents/motd.js')
 ];
-var commands = {
+const commands = {
 	crafter: require('./commands/crafter.js'),
 	items: require('./commands/items.js'),
 	motd: require('./commands/motd.js'),
@@ -12,24 +13,22 @@ var commands = {
 	territories: require('./commands/territories.js')
 };
 
-module.exports = function (bot) {
-	bot.on('ready', function () {
+export default (bot) => {
+	bot.on('ready', () => {
 		console.log('Gnarly is initialised and ready for use!');
-		agents.forEach(function (agent) {
-			agent.start(bot);
-		});
+		agents.forEach((agent) => agent.start(bot));
 	});
 
-	bot.on('message', function (message) {
+	bot.on('message', (message) => {
 		if (message.content.substr(0, 1) !== '!') return;
-		var structure = message.content.split(' ');
-		var command = structure[0];
-		var theRest = structure.slice(1, structure.length);
-		var context = theRest.join(' ');
+		const structure = message.content.split(' ');
+		const command = structure[0];
+		const theRest = structure.slice(1, structure.length);
+		const context = theRest.join(' ');
 
 		if (command === '!help') {
-			var help = Object.keys(commands).sort().map(function (key) {
-				var item = commands[key].help;
+			const help = Object.keys(commands).sort().map((key) => {
+				const item = commands[key].help;
 				return '\n!' + key + (item.context ? ' ' + item.context : '') + ' :: ' + item.info;
 			});
 			message.reply(help.join(''));
@@ -37,20 +36,15 @@ module.exports = function (bot) {
 			var commandFn = commands[command.substring(1)];
 			if (commandFn) {
 				Bluebird.resolve()
-					.then(commandFn(message, context))
-					.catch(function (err) {
-						console.error(err);
-					});
+					.then(commandFn.handle(message, context))
+					.catch((err) => console.error(err));
 			}
 		}
 	});
 
 	bot.on('disconnected', function () {
-		console.log('Disconnected, exiting!');
-		agents.forEach(function (agent) {
-			agent.stop();
-		});
-		process.exit(1);
+		console.log('Disconnected. Stopping agents!');
+		agents.forEach((agent) => agent.stop());
 	});
 
 	bot.on('debug', function (message) {

--- a/commands/crafter.js
+++ b/commands/crafter.js
@@ -1,21 +1,21 @@
 'use strict';
 
-var Bluebird = require('bluebird');
-var spreadsheet = require('../spreadsheet.js');
-var getRows = Bluebird.promisify(spreadsheet.api.getRows, spreadsheet.api);
+import Bluebird from 'bluebird';
+import * as spreadsheet from '../spreadsheet.js';
+const getRows = Bluebird.promisify(spreadsheet.api.getRows, spreadsheet.api);
 
-module.exports = function (message, context) {
-	return getRows(spreadsheet.sheets.crafters).then(function (data) {
-		data.forEach(function (row) {
+export function handle (message, context) {
+	return getRows(spreadsheet.sheets.crafters).then((data) => {
+		data.forEach((row) => {
 			if (context.toLowerCase() === row.item.toLowerCase()) {
-				var replies = ['\nGuild crafters for: ' + row.item];
-				replies.push('Primary: ' + row.primarycrafter);
-				replies.push('Secondary: ' + row.secondarycrafter);
-				replies.push('Tertiary: ' + row.tertiarycrafter);
+				var replies = [`\nGuild crafters for: ${row.item}`];
+				replies.push(`Primary: ${row.primarycrafter}`);
+				replies.push(`Secondary: ${row.secondarycrafter}`);
+				replies.push(`Tertiary: ${row.tertiarycrafter}`);
 				message.reply(replies.join('\n'));
 			}
 		});
 	});
 };
 
-module.exports.help = { context: '<item>', info: 'Replies with the guild crafters for the queried item' };
+export const help = { context: '<item>', info: 'Replies with the guild crafters for the queried item' };

--- a/commands/crafter.js
+++ b/commands/crafter.js
@@ -1,20 +1,16 @@
 'use strict';
 
-import Bluebird from 'bluebird';
-import * as spreadsheet from '../spreadsheet.js';
-
-const getRows = Bluebird.promisify(spreadsheet.api.getRows, {context: spreadsheet.api});
+import {getRows, sheets} from '../spreadsheet.js';
 
 export async function handle (message, context) {
-	const reply = Bluebird.promisify(message.reply, {context: message});
-	const data = await getRows(spreadsheet.sheets.crafters);
+	const data = await getRows(sheets.crafters);
 	for (let row of data) {
 		if (context.toLowerCase() === row.item.toLowerCase()) {
 			var replies = [`\nGuild crafters for: ${row.item}`];
 			replies.push(`Primary: ${row.primarycrafter}`);
 			replies.push(`Secondary: ${row.secondarycrafter}`);
 			replies.push(`Tertiary: ${row.tertiarycrafter}`);
-			await reply(replies.join('\n'));
+			await message.replyp(replies.join('\n'));
 		}
 	};
 };

--- a/commands/crafter.js
+++ b/commands/crafter.js
@@ -2,20 +2,21 @@
 
 import Bluebird from 'bluebird';
 import * as spreadsheet from '../spreadsheet.js';
-const getRows = Bluebird.promisify(spreadsheet.api.getRows, spreadsheet.api);
 
-export function handle (message, context) {
-	return getRows(spreadsheet.sheets.crafters).then((data) => {
-		data.forEach((row) => {
-			if (context.toLowerCase() === row.item.toLowerCase()) {
-				var replies = [`\nGuild crafters for: ${row.item}`];
-				replies.push(`Primary: ${row.primarycrafter}`);
-				replies.push(`Secondary: ${row.secondarycrafter}`);
-				replies.push(`Tertiary: ${row.tertiarycrafter}`);
-				message.reply(replies.join('\n'));
-			}
-		});
-	});
+const getRows = Bluebird.promisify(spreadsheet.api.getRows, {context: spreadsheet.api});
+
+export async function handle (message, context) {
+	const reply = Bluebird.promisify(message.reply, {context: message});
+	const data = await getRows(spreadsheet.sheets.crafters);
+	for (let row of data) {
+		if (context.toLowerCase() === row.item.toLowerCase()) {
+			var replies = [`\nGuild crafters for: ${row.item}`];
+			replies.push(`Primary: ${row.primarycrafter}`);
+			replies.push(`Secondary: ${row.secondarycrafter}`);
+			replies.push(`Tertiary: ${row.tertiarycrafter}`);
+			await reply(replies.join('\n'));
+		}
+	};
 };
 
 export const help = { context: '<item>', info: 'Replies with the guild crafters for the queried item' };

--- a/commands/items.js
+++ b/commands/items.js
@@ -2,13 +2,14 @@
 
 import Bluebird from 'bluebird';
 import * as spreadsheet from '../spreadsheet.js';
-const getRows = Bluebird.promisify(spreadsheet.api.getRows, spreadsheet.api);
 
-export function handle (message, context) {
-	return getRows(spreadsheet.sheets.crafters).then((data) => {
-		var items = data.map((row) => `\n${row.item.toLowerCase()}`);
-		message.reply(items.join(''));
-	});
+const getRows = Bluebird.promisify(spreadsheet.api.getRows, {context: spreadsheet.api});
+
+export async function handle (message, context) {
+	const reply = Bluebird.promisify(message.reply, {context: message});
+	const data = await getRows(spreadsheet.sheets.crafters);
+	const items = data.map((row) => `\n${row.item.toLowerCase()}`);
+	await reply(items.join(''));
 };
 
 export const help = { info: 'Lists all items available for use with other commands' };

--- a/commands/items.js
+++ b/commands/items.js
@@ -1,15 +1,11 @@
 'use strict';
 
-import Bluebird from 'bluebird';
-import * as spreadsheet from '../spreadsheet.js';
-
-const getRows = Bluebird.promisify(spreadsheet.api.getRows, {context: spreadsheet.api});
+import {getRows, sheets} from '../spreadsheet.js';
 
 export async function handle (message, context) {
-	const reply = Bluebird.promisify(message.reply, {context: message});
-	const data = await getRows(spreadsheet.sheets.crafters);
+	const data = await getRows(sheets.crafters);
 	const items = data.map((row) => `\n${row.item.toLowerCase()}`);
-	await reply(items.join(''));
+	await message.replyp(items.join(''));
 };
 
 export const help = { info: 'Lists all items available for use with other commands' };

--- a/commands/items.js
+++ b/commands/items.js
@@ -1,16 +1,14 @@
 'use strict';
 
-var Bluebird = require('bluebird');
-var spreadsheet = require('../spreadsheet.js');
-var getRows = Bluebird.promisify(spreadsheet.api.getRows, spreadsheet.api);
+import Bluebird from 'bluebird';
+import * as spreadsheet from '../spreadsheet.js';
+const getRows = Bluebird.promisify(spreadsheet.api.getRows, spreadsheet.api);
 
-module.exports = function (message, context) {
-	return getRows(spreadsheet.sheets.crafters).then(function (data) {
-		var items = data.map(function (row) {
-			return ('\n' + row.item.toLowerCase());
-		});
+export function handle (message, context) {
+	return getRows(spreadsheet.sheets.crafters).then((data) => {
+		var items = data.map((row) => `\n${row.item.toLowerCase()}`);
 		message.reply(items.join(''));
 	});
 };
 
-module.exports.help = { info: 'Lists all items available for use with other commands' };
+export const help = { info: 'Lists all items available for use with other commands' };

--- a/commands/motd.js
+++ b/commands/motd.js
@@ -1,15 +1,15 @@
 'use strict';
 
-var Bluebird = require('bluebird');
-var spreadsheet = require('../spreadsheet.js');
-var getRows = Bluebird.promisify(spreadsheet.api.getRows, spreadsheet.api);
+import Bluebird from 'bluebird';
+import * as spreadsheet from '../spreadsheet.js';
+const getRows = Bluebird.promisify(spreadsheet.api.getRows, spreadsheet.api);
 
-module.exports = function (message, context) {
-	return getRows(spreadsheet.sheets.info).then(function (data) {
-		data.forEach(function (row) {
+export function handle (message, context) {
+	return getRows(spreadsheet.sheets.info).then((data) => {
+		data.forEach((row) => {
 			if (row.name === 'MOTD') message.reply(row.message);
 		});
 	});
 };
 
-module.exports.help = { info: 'Replies with the current Message of the Day!' };
+export const help = { info: 'Replies with the current Message of the Day!' };

--- a/commands/motd.js
+++ b/commands/motd.js
@@ -1,15 +1,11 @@
 'use strict';
 
-import Bluebird from 'bluebird';
-import * as spreadsheet from '../spreadsheet.js';
-
-const getRows = Bluebird.promisify(spreadsheet.api.getRows, {context: spreadsheet.api});
+import {getRows, sheets} from '../spreadsheet.js';
 
 export async function handle (message, context) {
-	const reply = Bluebird.promisify(message.reply, {context: message});
-	const data = await getRows(spreadsheet.sheets.info);
+	const data = await getRows(sheets.info);
 	for (let row of data) {
-		if (row.name === 'MOTD') await reply(row.message);
+		if (row.name === 'MOTD') await message.replyp(row.message);
 	};
 };
 

--- a/commands/motd.js
+++ b/commands/motd.js
@@ -2,14 +2,15 @@
 
 import Bluebird from 'bluebird';
 import * as spreadsheet from '../spreadsheet.js';
-const getRows = Bluebird.promisify(spreadsheet.api.getRows, spreadsheet.api);
 
-export function handle (message, context) {
-	return getRows(spreadsheet.sheets.info).then((data) => {
-		data.forEach((row) => {
-			if (row.name === 'MOTD') message.reply(row.message);
-		});
-	});
+const getRows = Bluebird.promisify(spreadsheet.api.getRows, {context: spreadsheet.api});
+
+export async function handle (message, context) {
+	const reply = Bluebird.promisify(message.reply, {context: message});
+	const data = await getRows(spreadsheet.sheets.info);
+	for (let row of data) {
+		if (row.name === 'MOTD') await reply(row.message);
+	};
 };
 
 export const help = { info: 'Replies with the current Message of the Day!' };

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -2,11 +2,11 @@
 
 var Bluebird = require('bluebird');
 
-module.exports = function (message, context) {
+export function handle (message, context) {
 	message.reply('pong');
 
 	// make sure the function returns a promise even though we don't do anything async
 	return Bluebird.resolve();
 };
 
-module.exports.help = { info: 'Replies with pong' };
+export const help = { info: 'Replies with pong' };

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -1,12 +1,10 @@
 'use strict';
 
-var Bluebird = require('bluebird');
+import Bluebird from 'bluebird';
 
-export function handle (message, context) {
-	message.reply('pong');
-
-	// make sure the function returns a promise even though we don't do anything async
-	return Bluebird.resolve();
+export async function handle (message, context) {
+	const reply = Bluebird.promisify(message.reply, {context: message});
+	await reply('pong');
 };
 
 export const help = { info: 'Replies with pong' };

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -1,10 +1,7 @@
 'use strict';
 
-import Bluebird from 'bluebird';
-
 export async function handle (message, context) {
-	const reply = Bluebird.promisify(message.reply, {context: message});
-	await reply('pong');
+	await message.replyp('pong');
 };
 
 export const help = { info: 'Replies with pong' };

--- a/commands/territories.js
+++ b/commands/territories.js
@@ -3,19 +3,20 @@
 import moment from 'moment';
 import Bluebird from 'bluebird';
 import * as spreadsheet from '../spreadsheet.js';
-const getRows = Bluebird.promisify(spreadsheet.api.getRows, spreadsheet.api);
 
-export function handle (message, context) {
-	return getRows(spreadsheet.sheets.territories).then((data) => {
-		var territories = data.map((row) => {
-			var time = moment(row.lastfed)
-				.add(row.days, 'days')
-				.add(row.hours, 'hours')
-				.add(row.minutes, 'minutes');
-			return (`\n${row.territory} :: ${moment().to(time)}`);
-		});
-		message.reply(territories.join(''));
+const getRows = Bluebird.promisify(spreadsheet.api.getRows, {context: spreadsheet.api});
+
+export async function handle (message, context) {
+	const reply = Bluebird.promisify(message.reply, {context: message});
+	const data = await getRows(spreadsheet.sheets.territories);
+	const territories = data.map((row) => {
+		const time = moment(row.lastfed)
+			.add(row.days, 'days')
+			.add(row.hours, 'hours')
+			.add(row.minutes, 'minutes');
+		return `\n${row.territory} :: ${moment().to(time)}`;
 	});
+	await reply(territories.join(''));
 };
 
 export const help = { info: 'Replies with the guilds current territories and their food timers' };

--- a/commands/territories.js
+++ b/commands/territories.js
@@ -1,14 +1,10 @@
 'use strict';
 
 import moment from 'moment';
-import Bluebird from 'bluebird';
-import * as spreadsheet from '../spreadsheet.js';
-
-const getRows = Bluebird.promisify(spreadsheet.api.getRows, {context: spreadsheet.api});
+import {getRows, sheets} from '../spreadsheet.js';
 
 export async function handle (message, context) {
-	const reply = Bluebird.promisify(message.reply, {context: message});
-	const data = await getRows(spreadsheet.sheets.territories);
+	const data = await getRows(sheets.territories);
 	const territories = data.map((row) => {
 		const time = moment(row.lastfed)
 			.add(row.days, 'days')
@@ -16,7 +12,7 @@ export async function handle (message, context) {
 			.add(row.minutes, 'minutes');
 		return `\n${row.territory} :: ${moment().to(time)}`;
 	});
-	await reply(territories.join(''));
+	await message.replyp(territories.join(''));
 };
 
 export const help = { info: 'Replies with the guilds current territories and their food timers' };

--- a/commands/territories.js
+++ b/commands/territories.js
@@ -1,21 +1,21 @@
 'use strict';
 
-var moment = require('moment');
-var Bluebird = require('bluebird');
-var spreadsheet = require('../spreadsheet.js');
-var getRows = Bluebird.promisify(spreadsheet.api.getRows, spreadsheet.api);
+import moment from 'moment';
+import Bluebird from 'bluebird';
+import * as spreadsheet from '../spreadsheet.js';
+const getRows = Bluebird.promisify(spreadsheet.api.getRows, spreadsheet.api);
 
-module.exports = function (message, context) {
-	return getRows(spreadsheet.sheets.territories).then(function (data) {
-		var territories = data.map(function (row) {
+export function handle (message, context) {
+	return getRows(spreadsheet.sheets.territories).then((data) => {
+		var territories = data.map((row) => {
 			var time = moment(row.lastfed)
 				.add(row.days, 'days')
 				.add(row.hours, 'hours')
 				.add(row.minutes, 'minutes');
-			return ('\n' + row.territory + ' :: ' + moment().to(time));
+			return (`\n${row.territory} :: ${moment().to(time)}`);
 		});
 		message.reply(territories.join(''));
 	});
 };
 
-module.exports.help = { info: 'Replies with the guilds current territories and their food timers' };
+export const help = { info: 'Replies with the guilds current territories and their food timers' };

--- a/interval.js
+++ b/interval.js
@@ -1,18 +1,18 @@
 'use strict';
 
-var testMode = false;
-var tokens = {};
+let testMode = false;
+let tokens = {};
 
-module.exports.enableTestMode = function () {
+export function enableTestMode () {
 	testMode = true;
 };
 
-module.exports.disableTestMode = function () {
+export function disableTestMode () {
 	testMode = false;
 	tokens = {};
 };
 
-module.exports.set = function (cb, frequency) {
+export function set (cb, frequency) {
 	if (testMode) {
 		var token = Math.floor(Math.random() * 1000000); // largeish random number
 		tokens[token] = cb;
@@ -22,7 +22,7 @@ module.exports.set = function (cb, frequency) {
 	}
 };
 
-module.exports.clear = function (token) {
+export function clear (token) {
 	if (testMode) {
 		delete tokens[token];
 	} else {
@@ -30,7 +30,7 @@ module.exports.clear = function (token) {
 	}
 };
 
-module.exports.trigger = function (token) {
+export function trigger (token) {
 	if (testMode) {
 		return tokens[token]();
 	} else {

--- a/package.json
+++ b/package.json
@@ -4,12 +4,24 @@
   "description": "Discord bot for the Albion Online clan, Narwhals",
   "private": true,
   "main": "bot.js",
+  "babel": {
+    "presets": [
+      "es2015",
+      "stage-0"
+    ]
+  },
   "scripts": {
+    "start": "babel-node server.js",
     "test": "mocha"
   },
   "author": "Montague Monro",
   "license": "MIT",
   "dependencies": {
+    "babel-cli": "^6.2.0",
+    "babel-core": "^6.3.2",
+    "babel-polyfill": "^6.2.0",
+    "babel-preset-es2015": "^6.1.18",
+    "babel-preset-stage-0": "^6.1.18",
     "bluebird": "^3.0.6",
     "discord.js": "^5.0.1",
     "google-spreadsheet": "^1.0.1",

--- a/server.js
+++ b/server.js
@@ -1,11 +1,12 @@
 'use strict';
 
-var fs = require('fs');
-var path = require('path');
-var Discord = require('discord.js');
-var bot = require('./bot');
-var client = new Discord.Client();
-var config;
+import fs from 'fs';
+import path from 'path';
+import Discord from 'discord.js';
+import bot from './bot';
+
+const client = new Discord.Client();
+let config;
 
 try {
 	config = JSON.parse(fs.readFileSync(path.join(__dirname, './config.json'), 'UTF-8'));
@@ -19,4 +20,10 @@ try {
 }
 
 bot(client, config);
+
+bot.on('disconnected', () => {
+	console.log('Disconnected, exiting!');
+	process.exit(1);
+});
+
 client.login(config.auth.email, config.auth.password);

--- a/spreadsheet.js
+++ b/spreadsheet.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import GoogleSpreadsheet from 'google-spreadsheet';
+import Bluebird from 'bluebird';
 
 const SPREADSHEET_ID = '1H2rDTyrg4g1sGVbiWMW7dL-YEzQ4RJX7eD9dZNbrhHk';
 const spreadsheet = new GoogleSpreadsheet(SPREADSHEET_ID);
@@ -12,3 +13,5 @@ export const sheets = {
 };
 
 export const api = spreadsheet;
+
+export const getRows = Bluebird.promisify(spreadsheet.getRows, {context: spreadsheet});

--- a/spreadsheet.js
+++ b/spreadsheet.js
@@ -1,13 +1,14 @@
 'use strict';
 
-var GoogleSpreadsheet = require('google-spreadsheet');
-var SPREADSHEET_ID = '1H2rDTyrg4g1sGVbiWMW7dL-YEzQ4RJX7eD9dZNbrhHk';
-var spreadsheet = new GoogleSpreadsheet(SPREADSHEET_ID);
+import GoogleSpreadsheet from 'google-spreadsheet';
 
-module.exports.sheets = {
+const SPREADSHEET_ID = '1H2rDTyrg4g1sGVbiWMW7dL-YEzQ4RJX7eD9dZNbrhHk';
+const spreadsheet = new GoogleSpreadsheet(SPREADSHEET_ID);
+
+export const sheets = {
 	info: 1,
 	territories: 2,
 	crafters: 3
 };
 
-module.exports.api = spreadsheet;
+export const api = spreadsheet;

--- a/test/agents/motd.js
+++ b/test/agents/motd.js
@@ -15,15 +15,10 @@ describe('./agents/motd.js', () => {
 		interval.disableTestMode();
 	});
 
-	it('doesn\'t fail', () => {
+	it('doesn\'t fail', async () => {
 		const client = new FakeClient();
-		return Bluebird.resolve()
-			.then(() => {
-				const token = agent.start(client);
-				return interval.trigger(token);
-			})
-			.then(() => {
-				assert.notEqual(client.messages.length, 0);
-			});
+		const token = agent.start(client);
+		await interval.trigger(token);
+		assert.notEqual(client.messages.length, 0);
 	});
 });

--- a/test/agents/motd.js
+++ b/test/agents/motd.js
@@ -1,26 +1,28 @@
-var assert = require('assert');
-var Bluebird = require('bluebird');
-var interval = require('../../interval.js');
-var agent = require('../../agents/motd.js');
-var FakeClient = require('../util/fakeclient.js');
+'use strict';
 
-describe('./agents/motd.js', function () {
-	beforeEach(function () {
+import assert from 'assert';
+import Bluebird from 'bluebird';
+import * as interval from '../../interval.js';
+import * as agent from '../../agents/motd.js';
+import FakeClient from '../util/fakeclient.js';
+
+describe('./agents/motd.js', () => {
+	beforeEach(() => {
 		interval.enableTestMode();
 	});
 
-	afterEach(function () {
+	afterEach(() => {
 		interval.disableTestMode();
 	});
 
-	it('doesn\'t fail', function () {
-		var client = new FakeClient();
+	it('doesn\'t fail', () => {
+		const client = new FakeClient();
 		return Bluebird.resolve()
-			.then(function () {
-				var token = agent.start(client);
+			.then(() => {
+				const token = agent.start(client);
 				return interval.trigger(token);
 			})
-			.then(function () {
+			.then(() => {
 				assert.notEqual(client.messages.length, 0);
 			});
 	});

--- a/test/bot.js
+++ b/test/bot.js
@@ -1,25 +1,33 @@
 'use strict';
 
-var assert = require('assert');
-var bot = require('../bot.js');
-var FakeClient = require('./util/fakeclient.js');
-var FakeMessage = require('./util/fakemessage.js');
+import assert from 'assert';
+import bot from '../bot.js';
+import * as interval from '../interval.js';
+import FakeClient from './util/fakeclient.js';
+import FakeMessage from './util/fakemessage.js';
 
-describe('./bot.js', function () {
-	var client;
+describe('./bot.js', () => {
+	let client;
 
-	beforeEach(function () {
+	beforeEach(() => {
+		interval.enableTestMode();
 		client = bot(new FakeClient());
+		client.emit('ready');
 	});
 
-	it('help doesn\'t fail', function () {
-		var message = new FakeMessage('!help');
+	afterEach(() => {
+		client.emit('disconnected');
+		interval.disableTestMode();
+	});
+
+	it('help doesn\'t fail', () => {
+		const message = new FakeMessage('!help');
 		client.emit('message', message);
 		assert.equal(message.replies.length, 1);
 	});
 
-	it('ping works', function () {
-		var message = new FakeMessage('!ping');
+	it('ping works', () => {
+		const message = new FakeMessage('!ping');
 		client.emit('message', message);
 		assert.equal(message.replies.length, 1);
 		assert.equal(message.replies[0], 'pong');

--- a/test/commands/crafter.js
+++ b/test/commands/crafter.js
@@ -1,11 +1,13 @@
-var assert = require('assert');
-var command = require('../../commands/crafter.js');
-var FakeMessage = require('../util/fakemessage.js');
+'use strict';
 
-describe('./commands/crafter.js', function () {
-	it('doesn\'t fail', function () {
-		var message = new FakeMessage('!crafter light cloth');
-		return command(message, 'light cloth').then(function () {
+import assert from 'assert';
+import {handle} from '../../commands/crafter.js';
+import FakeMessage from '../util/fakemessage.js';
+
+describe('./commands/crafter.js', () => {
+	it('doesn\'t fail', () => {
+		const message = new FakeMessage('!crafter light cloth');
+		return handle(message, 'light cloth').then(() => {
 			assert.notEqual(message.replies.length, 0);
 		});
 	});

--- a/test/commands/crafter.js
+++ b/test/commands/crafter.js
@@ -5,10 +5,9 @@ import {handle} from '../../commands/crafter.js';
 import FakeMessage from '../util/fakemessage.js';
 
 describe('./commands/crafter.js', () => {
-	it('doesn\'t fail', () => {
+	it('doesn\'t fail', async () => {
 		const message = new FakeMessage('!crafter light cloth');
-		return handle(message, 'light cloth').then(() => {
-			assert.notEqual(message.replies.length, 0);
-		});
+		await handle(message, 'light cloth');
+		assert.notEqual(message.replies.length, 0);
 	});
 });

--- a/test/commands/items.js
+++ b/test/commands/items.js
@@ -1,11 +1,13 @@
-var assert = require('assert');
-var command = require('../../commands/items.js');
-var FakeMessage = require('../util/fakemessage.js');
+'use strict';
 
-describe('./commands/items.js', function () {
-	it('doesn\'t fail', function () {
-		var message = new FakeMessage('!items');
-		return command(message, '').then(function () {
+import assert from 'assert';
+import {handle} from '../../commands/items.js';
+import FakeMessage from '../util/fakemessage.js';
+
+describe('./commands/items.js', () => {
+	it('doesn\'t fail', () => {
+		const message = new FakeMessage('!items');
+		return handle(message, '').then(() => {
 			assert.notEqual(message.replies.length, 0);
 		});
 	});

--- a/test/commands/items.js
+++ b/test/commands/items.js
@@ -5,10 +5,9 @@ import {handle} from '../../commands/items.js';
 import FakeMessage from '../util/fakemessage.js';
 
 describe('./commands/items.js', () => {
-	it('doesn\'t fail', () => {
+	it('doesn\'t fail', async () => {
 		const message = new FakeMessage('!items');
-		return handle(message, '').then(() => {
-			assert.notEqual(message.replies.length, 0);
-		});
+		await handle(message, '');
+		assert.notEqual(message.replies.length, 0);
 	});
 });

--- a/test/commands/motd.js
+++ b/test/commands/motd.js
@@ -5,10 +5,9 @@ import {handle} from '../../commands/motd.js';
 import FakeMessage from '../util/fakemessage.js';
 
 describe('./commands/motd.js', () => {
-	it('doesn\'t fail', () => {
+	it('doesn\'t fail', async () => {
 		const message = new FakeMessage('!motd');
-		return handle(message, '').then(() => {
-			assert.notEqual(message.replies.length, 0);
-		});
+		await handle(message, '');
+		assert.notEqual(message.replies.length, 0);
 	});
 });

--- a/test/commands/motd.js
+++ b/test/commands/motd.js
@@ -1,11 +1,13 @@
-var assert = require('assert');
-var command = require('../../commands/motd.js');
-var FakeMessage = require('../util/fakemessage.js');
+'use strict';
 
-describe('./commands/motd.js', function () {
-	it('doesn\'t fail', function () {
-		var message = new FakeMessage('!motd');
-		return command(message, '').then(function () {
+import assert from 'assert';
+import {handle} from '../../commands/motd.js';
+import FakeMessage from '../util/fakemessage.js';
+
+describe('./commands/motd.js', () => {
+	it('doesn\'t fail', () => {
+		const message = new FakeMessage('!motd');
+		return handle(message, '').then(() => {
 			assert.notEqual(message.replies.length, 0);
 		});
 	});

--- a/test/commands/ping.js
+++ b/test/commands/ping.js
@@ -5,18 +5,16 @@ import {handle} from '../../commands/ping.js';
 import FakeMessage from '../util/fakemessage.js';
 
 describe('./commands/ping.js', () => {
-	it('doesn\'t fail', () => {
+	it('doesn\'t fail', async () => {
 		const message = new FakeMessage('!ping');
-		return handle(message, '').then(() => {
-			assert.notEqual(message.replies.length, 0);
-		});
+		await handle(message, '');
+		assert.notEqual(message.replies.length, 0);
 	});
 
-	it('returns "pong"', () => {
+	it('returns "pong"', async () => {
 		const message = new FakeMessage('!ping');
-		return handle(message, '').then(() => {
-			assert.equal(message.replies.length, 1);
-			assert.equal(message.replies[0], 'pong');
-		});
+		await handle(message, '');
+		assert.equal(message.replies.length, 1);
+		assert.equal(message.replies[0], 'pong');
 	});
 });

--- a/test/commands/ping.js
+++ b/test/commands/ping.js
@@ -1,18 +1,20 @@
-var assert = require('assert');
-var command = require('../../commands/ping.js');
-var FakeMessage = require('../util/fakemessage.js');
+'use strict';
 
-describe('./commands/ping.js', function () {
-	it('doesn\'t fail', function () {
-		var message = new FakeMessage('!ping');
-		return command(message, '').then(function () {
+import assert from 'assert';
+import {handle} from '../../commands/ping.js';
+import FakeMessage from '../util/fakemessage.js';
+
+describe('./commands/ping.js', () => {
+	it('doesn\'t fail', () => {
+		const message = new FakeMessage('!ping');
+		return handle(message, '').then(() => {
 			assert.notEqual(message.replies.length, 0);
 		});
 	});
 
-	it('returns "pong"', function () {
-		var message = new FakeMessage('!ping');
-		return command(message, '').then(function () {
+	it('returns "pong"', () => {
+		const message = new FakeMessage('!ping');
+		return handle(message, '').then(() => {
 			assert.equal(message.replies.length, 1);
 			assert.equal(message.replies[0], 'pong');
 		});

--- a/test/commands/territories.js
+++ b/test/commands/territories.js
@@ -1,11 +1,13 @@
-var assert = require('assert');
-var command = require('../../commands/territories.js');
-var FakeMessage = require('../util/fakemessage.js');
+'use strict';
 
-describe('./commands/territories.js', function () {
-	it('doesn\'t fail', function () {
-		var message = new FakeMessage('!territories');
-		return command(message, '').then(function () {
+import assert from 'assert';
+import {handle} from '../../commands/territories.js';
+import FakeMessage from '../util/fakemessage.js';
+
+describe('./commands/territories.js', () => {
+	it('doesn\'t fail', () => {
+		const message = new FakeMessage('!territories');
+		return handle(message, '').then(() => {
 			assert.notEqual(message.replies.length, 0);
 		});
 	});

--- a/test/commands/territories.js
+++ b/test/commands/territories.js
@@ -5,10 +5,9 @@ import {handle} from '../../commands/territories.js';
 import FakeMessage from '../util/fakemessage.js';
 
 describe('./commands/territories.js', () => {
-	it('doesn\'t fail', () => {
+	it('doesn\'t fail', async () => {
 		const message = new FakeMessage('!territories');
-		return handle(message, '').then(() => {
-			assert.notEqual(message.replies.length, 0);
-		});
+		await handle(message, '');
+		assert.notEqual(message.replies.length, 0);
 	});
 });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,4 @@
+--require babel-polyfill
 --reporter spec
+--compilers js:babel-core/register
 --recursive

--- a/test/util/fakeclient.js
+++ b/test/util/fakeclient.js
@@ -9,8 +9,9 @@ export default class extends EventEmitter {
 		this.messages = [];
 	}
 
-	sendMessage (channel, message) {
+	sendMessage (channel, message, cb) {
 		this.messages.push({channel, message});
+		if (cb) cb();
 	}
 
 };

--- a/test/util/fakeclient.js
+++ b/test/util/fakeclient.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var EventEmitter = require('events');
+import EventEmitter from 'events';
 
-module.exports = class extends EventEmitter {
+export default class extends EventEmitter {
 
 	constructor () {
 		super();
@@ -10,7 +10,7 @@ module.exports = class extends EventEmitter {
 	}
 
 	sendMessage (channel, message) {
-		this.messages.push({channel: channel, message: message});
+		this.messages.push({channel, message});
 	}
 
 };

--- a/test/util/fakemessage.js
+++ b/test/util/fakemessage.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import Bluebird from 'bluebird';
+
 export default class {
 
 	constructor (content) {
@@ -10,6 +12,11 @@ export default class {
 	reply (text, cb) {
 		this.replies.push(text);
 		if (cb) cb();
+	}
+
+	replyp (text) {
+		this.reply(text);
+		return Bluebird.resolve();
 	}
 
 };

--- a/test/util/fakemessage.js
+++ b/test/util/fakemessage.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports = class {
+export default class {
 
 	constructor (content) {
 		this.replies = [];

--- a/test/util/fakemessage.js
+++ b/test/util/fakemessage.js
@@ -7,8 +7,9 @@ export default class {
 		this.content = content;
 	}
 
-	reply (text) {
+	reply (text, cb) {
 		this.replies.push(text);
+		if (cb) cb();
 	}
 
 };


### PR DESCRIPTION
Lots of changes! This uses [babel](https://babeljs.io/) to let us use ES2015 and (proposed) ES7 features (namely async/await from ES7).

`npm start` continues to work, but `node server.js` will not as it requires `babel-node` to bootstrap some things.
